### PR TITLE
Resolve #153: show new tyls since last click in alerts

### DIFF
--- a/inc/languages/english/thankyoulike.lang.php
+++ b/inc/languages/english/thankyoulike.lang.php
@@ -90,9 +90,21 @@ $l['tyl_redirect_deleted'] = "Your {1} has been removed from the post";
 $l['tyl_redirect_back'] = "<br />You will be now taken back to the post.";
 
 
-$l['tyl_alert'] = '{1} thanked/liked your post<br /><b>"{2}"</b>.';
-$l['tyl_alert_like'] = '{1} liked your post<br /><b>"{2}"</b>.';
-$l['tyl_alert_thanks'] = '{1} thanked your post<br /><b>"{2}"</b>.';
+$l['tyl_alert'] = '{1} thanks you for or likes your post<br /><b>"{2}"</b>.';
+$l['tyl_alert_multi'] = '{1} and {2} others thank you for or like your post<br /><b>"{3}"</b>.';
+$l['tyl_alert_multi_one'] = '{1} and 1 other thank you for or like your post<br /><b>"{2}"</b>.';
+$l['tyl_alert_new'] = '{1} and {2} others thank you for or like ({3} new) your post<br /><b>"{4}"</b>.';
+$l['tyl_alert_new_one'] = '{1} and 1 other thank you for or like ({2} new) your post<br /><b>"{3}"</b>.';
+$l['tyl_alert_like'] = '{1} likes your post<br /><b>"{2}"</b>.';
+$l['tyl_alert_thanks'] = '{1} thanks you for your post<br /><b>"{2}"</b>.';
+$l['tyl_alert_like_multi'] = '{1} and {2} others like your post<br /><b>"{3}"</b>.';
+$l['tyl_alert_thanks_multi'] = '{1} and {2} others thank you for your post<br /><b>"{3}"</b>.';
+$l['tyl_alert_like_multi_one'] = '{1} and 1 other like your post<br /><b>"{2}"</b>.';
+$l['tyl_alert_thanks_multi_one'] = '{1} and 1 other thank you for your post<br /><b>"{2}"</b>.';
+$l['tyl_alert_like_new'] = '{1} and {2} others like ({3} new) your post<br /><b>"{4}"</b>.';
+$l['tyl_alert_thanks_new'] = '{1} and {2} others thank you ({3} new) for your post<br /><b>"{4}"</b>.';
+$l['tyl_alert_like_new_one'] = '{1} and 1 other like ({2} new) your post<br /><b>"{3}"</b>.';
+$l['tyl_alert_thanks_new_one'] = '{1} and 1 other thank you ({2} new) for your post<br /><b>"{3}"</b>.';
 $l['myalerts_setting_tyl'] = 'Receive an alert when someone adds a thank/like to my post?';
 $l['myalerts_setting_tyl_like'] = 'Receive an alert when someone adds a like to my post?';
 $l['myalerts_setting_tyl_thanks'] = 'Receive an alert when someone adds a thanks to my post?';

--- a/thankyoulike.php
+++ b/thankyoulike.php
@@ -245,7 +245,7 @@ if($mybb->input['action'] == "add")
 	$db->update_query('users', array('tyl_lastadddeldate' => TIME_NOW), 'uid='.intval($mybb->user['uid']));
 
 	// If a compatible version of MyAlerts exists, then add an alert for this tyl.
-	tyl_recordAlertThankyou();
+	tyl_manage_alert_for_added_tyl($post, $mybb->user['uid']);
 
 	if($tlid)
 	{
@@ -335,10 +335,8 @@ if($mybb->input['action'] == "del")
 		{
 			// process delete
 			$db->delete_query($prefix."thankyoulike", "tlid='".$tyl_r['tlid']."'", "1");
-			// If a compatible version of MyAlerts is active, then delete any unread alert for the deleted tyl.
-			if(tyl_have_myalerts() && $mybb->user['uid']){
-				$db->query("DELETE FROM ".TABLE_PREFIX."alerts WHERE from_user_id={$mybb->user['uid']} AND object_id='{$pid}' AND unread=1 LIMIT 1");
-			}
+			// If a compatible version of MyAlerts is active, then manage any existing unread alert for the deleted tyl.
+			tyl_manage_alert_for_deleted_tyl($post, $mybb->user['uid']);
 			// Update user's last like add/del date
 			$db->update_query('users', array('tyl_lastadddeldate' => TIME_NOW), 'uid='.intval($mybb->user['uid']));
 			// Update counts


### PR DESCRIPTION
When a new tyl is added to a post, update any tyl alert for that post
rather than creating a new alert. Show the total number of tyls for the
post as well as the total number of new tyls since the author last
clicked the tyl alert for the post.

TESTERS NOTE: be sure to run the following database query prior to
testing (it is run on upgrade, but this commit doesn't bump the
version number, so the upgrade won't run):

`ALTER TABLE mybb_posts ADD `tyl_last_alerted_tyl_id` int unsigned NOT NULL default '0'`

(Replace `mybb_` with your custom prefix as necessary.)