### PR TITLE
Fully fix #295 by removing creation of new indexes from auto-upgrade

### DIFF
--- a/inc/plugins/thankyoulike.php
+++ b/inc/plugins/thankyoulike.php
@@ -642,37 +642,6 @@ function tyl_check_update_db_table_and_cols($from_version = false)
 				".$db->build_create_table_collation().";");
 	}
 
-	if($from_version !== false && $from_version < 30308)
-	{
-		// These indexes speed up the member profile tyl statistics (tabulated display of date range counts of tyls).
-		$query = $db->query("SHOW INDEX FROM ".TABLE_PREFIX.$prefix."thankyoulike WHERE Key_name='uid_dateline'");
-		if($db->num_rows($query) == 0)
-		{
-			$db->query("ALTER TABLE ".TABLE_PREFIX.$prefix."thankyoulike ADD KEY uid_dateline  (uid , dateline)");
-		}
-		$db->free_result($query);
-		$query = $db->query("SHOW INDEX FROM ".TABLE_PREFIX.$prefix."thankyoulike WHERE Key_name='puid_dateline'");
-		if($db->num_rows($query) == 0)
-		{
-			$db->query("ALTER TABLE ".TABLE_PREFIX.$prefix."thankyoulike ADD KEY puid_dateline (puid, dateline)");
-		}
-		$db->free_result($query);
-		$query = $db->query("SHOW INDEX FROM ".TABLE_PREFIX.$prefix."thankyoulike WHERE Key_name='puid_uid'");
-		if($db->num_rows($query) == 0)
-		{
-			$db->query("ALTER TABLE ".TABLE_PREFIX.$prefix."thankyoulike ADD KEY puid_uid (puid, uid)");
-		}
-		$db->free_result($query);
-
-		// This index speeds up the determination of the member profile trophy post.
-		$query = $db->query("SHOW INDEX FROM ".TABLE_PREFIX.$prefix."thankyoulike WHERE Key_name='puid_pid'");
-		if($db->num_rows($query) == 0)
-		{
-			$db->query("ALTER TABLE ".TABLE_PREFIX.$prefix."thankyoulike ADD KEY puid_pid (puid, pid)");
-		}
-		$db->free_result($query);
-	}
-
 	// Added puid field after v1.0 so check for that
 	if($db->table_exists($prefix.'thankyoulike') && !$db->field_exists('puid', $prefix.'thankyoulike'))
 	{


### PR DESCRIPTION
PR #296, which supports semi-automated creation of the indexes
via the plugin's ACP listing - was not enough. The full fix is
to totally remove the auto-creation of the indexes on plugin
auto-upgrade, and rely on users semi-automatically creating
them per the feature introduced by that PR.

This is because if/when the index creation times out on plugin
auto-upgrade, the upgrade process will not have completed, and
the admin might not know to repeat it by deactivating and then
reactivating the plugin after manually creating the indexes.