### PR TITLE
Add $post global for compatibility with hide mod +

### DIFF
--- a/upload/inc/plugins/thankyoulike.php
+++ b/upload/inc/plugins/thankyoulike.php
@@ -91,7 +91,7 @@ function thankyoulike_info()
 		"website"	=> "https://community.mybb.com/thread-169382.html",
 		"author"	=> "MyBB Group with love <3",
 		"authorsite"	=> "https://community.mybb.com/thread-169382.html",
-		"version"	=> "3.4.2",
+		"version"	=> "3.4.3",
 		// Constructed by converting each digit of "version" above into two digits (zero-padded if necessary),
 		// then concatenating them, then removing any leading zero to avoid the value being interpreted as octal.
 		"version_code"  => 30402,

--- a/upload/inc/plugins/thankyoulike.php
+++ b/upload/inc/plugins/thankyoulike.php
@@ -2602,7 +2602,7 @@ function tyl_myalerts_formatter_load()
 
 function thankyoulike_memprofile()
 {
-	global $db, $mybb, $lang, $memprofile, $templates, $tyl_memprofile, $tyl_profile_stats, $uid;
+	global $db, $mybb, $lang, $memprofile, $templates, $tyl_memprofile, $tyl_profile_stats, $uid, $post;
 	$prefix = 'g33k_thankyoulike_';
 
 	$lang->load("thankyoulike");


### PR DESCRIPTION
Hide mod + fetches the $post['pid'] to check whether the user has access to the hidden content. Without this global, hide mod + cannot verify access if hidden content appears as the top liked message in the user's profile.