### PR TITLE
Fix #336: PHP 8 warning: Undefined property: MyLanguage::$thankyoulike

### DIFF
--- a/upload/inc/plugins/thankyoulike.php
+++ b/upload/inc/plugins/thankyoulike.php
@@ -2631,7 +2631,7 @@ function tyl_myalerts_formatter_load()
 
 			public function init()
 			{
-				if(!$this->lang->thankyoulike) {
+				if(empty($this->lang->thankyoulike)) {
 					$this->lang->load('thankyoulike');
 				}
 			}


### PR DESCRIPTION
Resolves #336