### PR TITLE
Implement all-in-one recounts (no pagination)

### DIFF
--- a/upload/inc/languages/english/admin/config_thankyoulike.lang.php
+++ b/upload/inc/languages/english/admin/config_thankyoulike.lang.php
@@ -171,6 +171,8 @@ $l['tyl_recount'] = "Recount thanks/likes";
 $l['tyl_recount_do_desc'] = "When this is run, the thanks/likes count for each user and post will be updated to reflect its current live value based on the data in the database.";
 $l['tyl_success_thankyoulike_rebuilt'] = "The thanks/likes have been recounted successfully.";
 
+$l['tyl_recount_boardclosed_reason'] ='The thanks/likes are being recounted.';
+
 $l['tyl_admin_log_action'] = "Thanks/likes successfully recounted.";
 
 $l['tyl_recount2'] = "(Re)initialise last alerted thank/like for each post";


### PR DESCRIPTION
As indicated in a comment in the code, we here drop pagination during the plugin's ACP recount routines, and instead run all our queries at once. This is because we received a report[1] that on a big board with millions of tyls, the page-by-page recounting was slow, and got slower page by page, becoming effectively never-ending, whereas even on that big board, these queries completed within seconds, such that there seems to be no compelling reason to split the task over multiple pages, and a compelling one not to.

[1] https://community.mybb.com/thread-239004.html

This commit is in part heavily based on the script that I wrote in response to that report to generate and test these queries, as attached to this post[2].

[2]
https://community.mybb.com/thread-239004-post-1388050.html#pid1388050